### PR TITLE
Smoother animations between columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,16 @@ The package exports a `Board` component which is the one you'd use to render the
 | renderRow           | `({ item, index }) => {}`                               |   yes    | Function responsible for rendering row item                             |
 | renderColumnWrapper | `({ item, index, columnComponent, layoutProps }) => {}` |   yes    | Function responsible for rendering wrapper of the column                |
 | onRowPress          | `(row) => {}`                                           |    no    | Function invoked when row pressed                                       |
+| onDragStart         | `() => {}`                                              |    no    | Function invoked when drag is started                                   |
 | onDragEnd           | `(fromColumnId, toColumnId, row) => {}`                 |    no    | Function invoked when drag is finished                                  |
 | style               | `StyleProp`                                             |    no    | Style of the board                                                      |
 | columnWidth         | `number`                                                |    no    | Initial min column width                                                |
 | accessoryRight      | `function\|View`                                        |    no    | Render end of the board. Useful when rendering virtual add more column. |
 | activeRowStyle      | `StyleProp`                                             |    no    | A custom style for the row when being dragged.                          |
 | activeRowRotation   | `number`                                                |    no    | Degrees to rotate the row when being dragged. Default is 8.             |
-| scrollThreshold     | `number`                                                |    no    | Offset X or Y to calculate scroll from. Default is 50.                  |
+| xScrollThreshold    | `number`                                                |    no    | Offset from X to calculate scroll from. Default is 50.                  |
+| yScrollThreshold    | `number`                                                |    no    | Offset from Y for the rows. Default is 50.                              |
+| dragSpeedFactor     | `number`                                                |    no    | When dragging you can accelerate the scrollTo position. Default is 1.   |
 
 ### `Repository`
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ The package exports a `Board` component which is the one you'd use to render the
 | style               | `StyleProp`                                             |    no    | Style of the board                                                      |
 | columnWidth         | `number`                                                |    no    | Initial min column width                                                |
 | accessoryRight      | `function\|View`                                        |    no    | Render end of the board. Useful when rendering virtual add more column. |
+| activeRowStyle      | `StyleProp`                                             |    no    | A custom style for the row when being dragged.                          |
+| activeRowRotation   | `number`                                                |    no    | Degrees to rotate the row when being dragged. Default is 8.             |
+| scrollThreshold     | `number`                                                |    no    | Offset X or Y to calculate scroll from. Default is 50.                  |
 
 ### `Repository`
 

--- a/src/components/column.js
+++ b/src/components/column.js
@@ -13,6 +13,7 @@ const Column = ({
   renderRow,
   scrollEnabled,
   columnWidth,
+  onDragStartCallback,
   onRowPress = () => {},
 }) => {
   const [rows, setRows] = useState(column.rows);
@@ -43,6 +44,7 @@ const Column = ({
           renderItem={renderRow}
           hidden={item.hidden}
           onPress={() => onRowPress(item)}
+          onDragStartCallback={onDragStartCallback}
         />
       </View>
     );

--- a/src/components/row.js
+++ b/src/components/row.js
@@ -4,8 +4,11 @@ import Animated from 'react-native-reanimated';
 
 import style from '../style';
 
-const Row = memo(({ row, move, renderItem, hidden, onPress }) => {
+const Row = memo(({ row, move, renderItem, hidden, onPress, onDragStartCallback }) => {
   const onDragBegin = () => {
+    if (onDragStartCallback) {
+      onDragStartCallback();
+    }
     const hoverComponent = renderItem({
       move,
       item: row.data,

--- a/src/index.js
+++ b/src/index.js
@@ -30,8 +30,11 @@ const DraggableBoard = ({
   accessoryRight,
   activeRowStyle,
   activeRowRotation = 8,
-  scrollThreshold = SCROLL_THRESHOLD,
-  onRowPress = () => {},
+  xScrollThreshold = SCROLL_THRESHOLD,
+  yScrollThreshold = SCROLL_THRESHOLD,
+  dragSpeedFactor = 1,
+  onRowPress = () => { },
+  onDragStart = () => { },
   onDragEnd = () => { },
   style: boardStyle,
   horizontal = true,
@@ -124,16 +127,20 @@ const DraggableBoard = ({
 
       if (columnAtPosition && scrollViewRef.current) {
         // handle scroll horizontal
-        if (x + scrollThreshold > Utils.deviceWidth) {
+        if (x + xScrollThreshold > Utils.deviceWidth) {
           scrollOffset.current += SCROLL_STEP;
           scrollViewRef.current.scrollTo({
-            x: scrollOffset.current,
+            x: scrollOffset.current * dragSpeedFactor,
+            y: 0,
+            animated: true
           });
           repository.measureColumnsLayout();
-        } else if (x < scrollThreshold) {
+        } else if (x < xScrollThreshold) {
           scrollOffset.current -= SCROLL_STEP;
           scrollViewRef.current.scrollTo({
-            x: scrollOffset.current,
+            x: scrollOffset.current / dragSpeedFactor,
+            y: 0,
+            animated: true
           });
           repository.measureColumnsLayout();
         }
@@ -180,7 +187,7 @@ const DraggableBoard = ({
             transform: [{ translateX }, { translateY }, { rotate: `${activeRowRotation}deg` }],
           },
           {
-            top: y - scrollThreshold,
+            top: y - yScrollThreshold,
             left: x,
             width,
             height,
@@ -229,6 +236,7 @@ const DraggableBoard = ({
           scrollEnabled={!movingMode}
           columnWidth={columnWidth}
           onRowPress={onRowPress}
+          onDragStartCallback={onDragStart}
         />
       );
 

--- a/src/index.js
+++ b/src/index.js
@@ -28,8 +28,11 @@ const DraggableBoard = ({
   renderRow,
   columnWidth,
   accessoryRight,
+  activeRowStyle,
+  activeRowRotation = 8,
+  scrollThreshold = SCROLL_THRESHOLD,
   onRowPress = () => {},
-  onDragEnd = () => {},
+  onDragEnd = () => { },
   style: boardStyle,
   horizontal = true,
 }) => {
@@ -121,13 +124,13 @@ const DraggableBoard = ({
 
       if (columnAtPosition && scrollViewRef.current) {
         // handle scroll horizontal
-        if (x + SCROLL_THRESHOLD > Utils.deviceWidth) {
+        if (x + scrollThreshold > Utils.deviceWidth) {
           scrollOffset.current += SCROLL_STEP;
           scrollViewRef.current.scrollTo({
             x: scrollOffset.current,
           });
           repository.measureColumnsLayout();
-        } else if (x < SCROLL_THRESHOLD) {
+        } else if (x < scrollThreshold) {
           scrollOffset.current -= SCROLL_STEP;
           scrollViewRef.current.scrollTo({
             x: scrollOffset.current,
@@ -165,17 +168,19 @@ const DraggableBoard = ({
 
   const renderHoverComponent = () => {
     if (hoverComponent && hoverRowItem.current) {
+      
       const row = repository.findRow(hoverRowItem.current);
-
+      
       if (row && row.layout) {
         const { x, y, width, height } = row.layout;
         const hoverStyle = [
           style.hoverComponent,
+          activeRowStyle,
           {
-            transform: [{ translateX }, { translateY }, { rotate: '8deg' }],
+            transform: [{ translateX }, { translateY }, { rotate: `${activeRowRotation}deg` }],
           },
           {
-            top: y - SCROLL_THRESHOLD,
+            top: y - scrollThreshold,
             left: x,
             width,
             height,


### PR DESCRIPTION
** This is newer pull request which also combines features from https://github.com/hungga1711/react-native-dnd-board/pull/3 (which I will close).**

This enhancement update allows for some customisation to the dragged row via the main `Board` props. For instance I add a  card shadow when a row is dragged and reduce the rotation (which in turn needs some tweaking of the `yScrollThreshold`).

It also introduces an `onDragStart` which is useful for things like triggering an haptic event when dragging starts.

The `scrollThreshold` has been split into `xScrollThreshold` and `yScrollThreshold` for more control.

There is a `dragSpeedFactor` prop that changes the `scrollTo` position of the scrollview by the give factor (default to 1). Still not perfectly smooth but it allows for a little more control.

Added to the Readme too. 

I hope you find this useful.

By the way thank you for your work on this library @hungga1711. 🙏